### PR TITLE
Add logging to the ECS Task Definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+terraform.*
+.terraform/

--- a/bucket.tf
+++ b/bucket.tf
@@ -1,5 +1,5 @@
 resource "aws_ecr_repository" "ecr" {
-  name = "romans"
+  name = "academy-repository"
 }
 
 resource "aws_iam_user" "deploy" {

--- a/bucket.tf
+++ b/bucket.tf
@@ -1,5 +1,5 @@
 resource "aws_ecr_repository" "ecr" {
-  name = "academy-repository"
+  name = "academy"
 }
 
 resource "aws_iam_user" "deploy" {

--- a/cluster.tf
+++ b/cluster.tf
@@ -1,3 +1,4 @@
+data "aws_region" "current" {}
 
 resource "aws_ecs_cluster" "cluster" {
   name = "and-academy"
@@ -102,7 +103,7 @@ resource "aws_ecs_task_definition" "service" {
       options: {
         "awslogs-group": aws_cloudwatch_log_group.logs.name,
         "awslogs-stream-prefix": "academy-logs",
-        "awslogs-region": "eu-west-2"
+        "awslogs-region": data.aws_region.current.name
       }
     }
   }])

--- a/cluster.tf
+++ b/cluster.tf
@@ -3,13 +3,11 @@ resource "aws_ecs_cluster" "cluster" {
   name = "and-academy"
 }
 
-
 resource "aws_alb" "main" {
   name            = "academy"
   subnets         = module.vpc.public_subnets
   security_groups = [aws_security_group.main.id]
 }
-
 
 resource "aws_alb_target_group" "main" {
   name = "academy"
@@ -18,7 +16,6 @@ resource "aws_alb_target_group" "main" {
   vpc_id = module.vpc.vpc_id
   target_type = "ip"
 }
-
 
 resource "aws_alb_listener" "main" {
   load_balancer_arn = aws_alb.main.arn
@@ -31,21 +28,17 @@ resource "aws_alb_listener" "main" {
   }
 }
 
-
 resource "aws_ecs_service" "main" {
   name            = "academy"
   cluster         = aws_ecs_cluster.cluster.id
   task_definition = aws_ecs_task_definition.service.arn
   desired_count   = 5
   launch_type     = "FARGATE"
-  #iam_role        = aws_iam_role.main.arn
 
   network_configuration {
-    #assign_public_ip = true
     security_groups = [aws_security_group.main.id]
     subnets         = module.vpc.private_subnets
   }
-
 
   load_balancer {
     target_group_arn = aws_alb_target_group.main.arn
@@ -57,8 +50,6 @@ resource "aws_ecs_service" "main" {
     aws_alb_listener.main
   ]
 }
-
-
 
 resource "aws_security_group" "main" {
   vpc_id      = module.vpc.vpc_id
@@ -85,21 +76,6 @@ resource "aws_security_group" "main" {
   }
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 resource "aws_ecs_task_definition" "service" {
   family                = "service"
   network_mode             = "awsvpc"
@@ -120,7 +96,14 @@ resource "aws_ecs_task_definition" "service" {
         containerPort: 80,
         hostPort: 80
       }
-    ]
+    ],
+    logConfiguration: {
+      logDriver: "awslogs",
+      options: {
+        "awslogs-group": aws_cloudwatch_log_group.logs.name,
+        "awslogs-stream-prefix": "academy-logs"
+      }
+    }
   }])
 }
 
@@ -142,7 +125,6 @@ resource "aws_iam_role" "main" {
 }
 EOF
 }
-
 
 resource "aws_iam_policy" "main" {
   policy = <<EOF

--- a/cluster.tf
+++ b/cluster.tf
@@ -101,7 +101,8 @@ resource "aws_ecs_task_definition" "service" {
       logDriver: "awslogs",
       options: {
         "awslogs-group": aws_cloudwatch_log_group.logs.name,
-        "awslogs-stream-prefix": "academy-logs"
+        "awslogs-stream-prefix": "academy-logs",
+        "awslogs-region": "eu-west-2"
       }
     }
   }])

--- a/logs.tf
+++ b/logs.tf
@@ -1,0 +1,3 @@
+resource "aws_cloudwatch_log_group" "logs" {
+  name = "academy-log-group"
+}


### PR DESCRIPTION
We create a CloudWatch Log Group to hold the log streams created by the containers. The region is hardcoded at the moment, so will probably need to be taken from the terraform environment.